### PR TITLE
Add MultiOS support

### DIFF
--- a/main/Program.cs
+++ b/main/Program.cs
@@ -19,7 +19,7 @@ foreach (var solution in Directory.GetFiles("solutions", "*.cs"))
     foreach (var oldFile in oldFiles) File.Delete(oldFile);
     File.Copy(solution, Path.Combine("code", "Solution.cs"));
     var name = Path.GetFileNameWithoutExtension(solution);
-    var info = new ProcessStartInfo("cmd.exe", "/C dotnet run --project tester");
+    var info = new ProcessStartInfo("dotnet", "run --project tester");
     var process = Process.Start(info);
     process?.WaitForExit();
     if (process?.ExitCode != 0)


### PR DESCRIPTION
## Description

The current implementation of the tester is windows based due to the usage of `cmd.exe` command

https://github.com/leynier/matcom-tester/blob/3b5d75b8c05d0778017437a2344f7700a9389100/main/Program.cs#L22

Due to that the tester doesn't work on Linux or other OS.

## Tentative Fix
`dotnet` can be used across different OS, so the `cmd.exe` command can be removed in favor of the direct usage of `dotnet`.

> **Note**: This fix need to be tested on Windows.